### PR TITLE
feat(@angular/cli): add some rules from tslint 4.5

### DIFF
--- a/packages/@angular/cli/blueprints/ng/files/tslint.json
+++ b/packages/@angular/cli/blueprints/ng/files/tslint.json
@@ -3,6 +3,7 @@
     "node_modules/codelyzer"
   ],
   "rules": {
+    "arrow-return-shorthand": true,
     "callable-types": true,
     "class-name": true,
     "comment-format": [
@@ -42,15 +43,19 @@
     ],
     "no-construct": true,
     "no-debugger": true,
+    "no-duplicate-super": true,
     "no-empty": false,
     "no-empty-interface": true,
     "no-eval": true,
     "no-inferrable-types": [true, "ignore-params"],
+    "no-misused-new": true,
+    "no-non-null-assertion": true,
     "no-shadowed-variable": true,
     "no-string-literal": false,
     "no-string-throw": true,
     "no-switch-case-fall-through": true,
     "no-trailing-whitespace": true,
+    "no-unnecessary-initializer": true,
     "no-unused-expression": true,
     "no-use-before-declare": true,
     "no-var-keyword": true,


### PR DESCRIPTION
Adds a few rules introduced by tslint 4.4 and 4.5

- [arrow-return-shorthand](https://palantir.github.io/tslint/rules/arrow-return-shorthand/)
- [no-duplicate-super](https://palantir.github.io/tslint/rules/no-duplicate-super/)
- [no-import-side-effect](https://palantir.github.io/tslint/rules/no-import-side-effect/)
- [no-misused-new](https://palantir.github.io/tslint/rules/no-misused-new/)
- [no-non-null-assertion](https://palantir.github.io/tslint/rules/no-non-null-assertion/)
- [no-unnecessary-initializer](https://palantir.github.io/tslint/rules/no-unnecessary-initializer/)